### PR TITLE
fix: reduce MAXTFS/MAXMIRS from 1500 to 1000 to fix SIGABRT (exit 134)

### DIFF
--- a/netZooC/puma/PUMA.c
+++ b/netZooC/puma/PUMA.c
@@ -40,8 +40,8 @@ PUMAs-specific modifications (compared to PANDA) are highlighted with *PUMA
 #define NORMAL "\033[0m"
 
 #define MAXGENES 20000
-#define MAXTFS 1500
-#define MAXMIRS 1500 // *PUMA: changed this from 1000 to 1500 to allow for more regulators
+#define MAXTFS 1000
+#define MAXMIRS 1000 // *PUMA
 #define MAXCONDITIONS 500
 #define BUFSIZE 10000
 #define MAXPATHLENGTH 500


### PR DESCRIPTION
## Problem

CI fails on both ubuntu-latest and macos-latest with exit code 134 (SIGABRT) when running PUMA.

**Root cause:** PUMA REGULATION struct array with MAXTFS=1500 creates a ~2 GB __DATA segment that exceeds the macOS Mach-O segment size limit. This causes dyld to fail loading shared libraries (libc++.1.dylib, libSystem.B.dylib), aborting the process before main() even runs.

## Fix

Reduce MAXTFS and MAXMIRS from 1500 back to 1000 (matching PANDA). This brings the __DATA segment from ~2.0 GB to ~1.83 GB, within limits.

## Verification

- PUMA builds and runs successfully on macOS (arm64)
- Output is byte-identical to the reference ToyOutput_FinalNetwork.pairs
- All 4 PUMA tests pass (format, nonzero edges, miRNA check, network comparison)
- All 3 PANDA tests continue to pass

Fixes https://github.com/netZoo/netZooC/actions/runs/22497581186
